### PR TITLE
perf: re-use the same buffer

### DIFF
--- a/src/memory/linux.rs
+++ b/src/memory/linux.rs
@@ -98,13 +98,15 @@ impl ProcessTraits for Process {
         &self, 
         sign: &Signature
     ) -> Result<usize, ProcessError> {
+        let mut buff = Vec::new();
+
         for region in &self.maps {
             let remote = RemoteIoVec {
                 base: region.from,
                 len: region.size
             };
 
-            let mut buff = vec![0; region.size];
+            buff.resize(region.size, 0);
 
             let slice = IoSliceMut::new(buff.as_mut_slice());
 
@@ -122,8 +124,7 @@ impl ProcessTraits for Process {
                 }
             }
 
-            let res = find_signature(buff.as_slice(), sign);
-            if let Some(offset) = res {
+            if let Some(offset) = find_signature(buff.as_slice(), sign) {
                 return Ok(remote.base + offset);
             }
         }

--- a/src/memory/windows.rs
+++ b/src/memory/windows.rs
@@ -109,39 +109,32 @@ impl ProcessTraits for Process {
         &self, 
         sign: &Signature
     ) -> Result<usize, ProcessError> {
-        for chunk in self.maps.chunks(32) {
-            let mut buffs: Vec<Vec<u8>> = chunk.iter()
-                .map(|region| vec![0; region.size])
-                .collect();
+        let mut buf = Vec::new();
 
-            // TODO use zip?
-            for (index, region) in chunk.iter().enumerate() {
-                let mut bytesread: usize = 0;
+        for region in self.maps.iter() {
+            buf.resize(region.size, 0);
 
-                let res = unsafe { ReadProcessMemory(
-                    self.handle as HANDLE,
-                    region.from as *mut c_void,
-                    buffs[index].as_mut_ptr() as *mut c_void,
-                    region.size,
-                    Some(&mut bytesread)
-                ) };
+            let mut bytesread: usize = 0;
 
-                if let Err(error) = res.ok() {
-                    // Stupid error code that we should
-                    // ignore during memory regions
-                    // collection
-                    if error.code().0 == -2147024597 {
-                        continue
-                    } else {
-                        res.ok()?
-                    };
+            let res = unsafe { ReadProcessMemory(
+                self.handle,
+                region.from as *mut c_void,
+                buf.as_mut_ptr() as *mut c_void,
+                region.size,
+                Some(&mut bytesread)
+            ) };
+
+            if let Err(error) = res.ok() {
+                // Stupid error code that we should
+                // ignore during memory regions
+                // collection
+                if error.code().0 == -2147024597 {
+                    continue
                 }
+            }
 
-                let res = find_signature(&buffs[index], sign);
-
-                if let Some(offset) = res {
-                    return Ok(region.from + offset)
-                }
+            if let Some(offset) = find_signature(&buf[..bytesread], sign) {
+                return Ok(region.from + offset)
             }
         }
 

--- a/src/memory/windows.rs
+++ b/src/memory/windows.rs
@@ -110,11 +110,10 @@ impl ProcessTraits for Process {
         sign: &Signature
     ) -> Result<usize, ProcessError> {
         let mut buf = Vec::new();
+        let mut bytesread: usize = 0;
 
         for region in self.maps.iter() {
             buf.resize(region.size, 0);
-
-            let mut bytesread: usize = 0;
 
             let res = unsafe { ReadProcessMemory(
                 self.handle,
@@ -131,6 +130,8 @@ impl ProcessTraits for Process {
                 if error.code().0 == -2147024597 {
                     continue
                 }
+
+                return Err(error.into());
             }
 
             if let Some(offset) = find_signature(&buf[..bytesread], sign) {


### PR DESCRIPTION
Avoid allocations for memory regions and re-use the same buffer instead