### PR TITLE
refactor: simplify errors via thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,6 +746,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "smol",
+ "thiserror",
  "windows",
 ]
 
@@ -905,18 +906,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ rosu-pp = "0.9.5"
 serde = { version = "1.0.189", features = ["derive"] }
 serde_json = "1.0.107"
 serde_repr = "0.1.16"
+thiserror = "1.0.50"
 smol = "1.3.0"
 
 [target.'cfg(unix)'.dependencies]

--- a/src/memory/error.rs
+++ b/src/memory/error.rs
@@ -17,7 +17,7 @@ pub enum ProcessError {
     },
     #[error("Got error when converting bytes to string!")]
     FromUtf8Error,
-    #[error("Got error during type convertion")]
+    #[error("Got error during type conversion")]
     ConvertionError,
     #[error("Trying to read bad address\nAddress: {0:X}, Length: {1:X}")]
     BadAddress(usize, usize),


### PR DESCRIPTION
This cleans up errors by importing and using `thiserror`. Since `tungstenite` is already using it, nothing is added to the dependency tree.

Still, this isn't really necessary and some people prefer manual implementations so feel free to just close this if you're not a fan 😃 