### PR TITLE
Fix panic when opening in browser

### DIFF
--- a/src/websockets.rs
+++ b/src/websockets.rs
@@ -15,11 +15,9 @@ pub fn server_thread(
             let (stream, _) = server.accept()
                 .await.unwrap();
 
-            let ws = accept_async(stream)
-                .await
-                .unwrap(); // TODO check res
-
-            let _ = tx.send(ws);
+            if let Ok(ws) = accept_async(stream).await {
+                let _ = tx.send(ws);
+            }
         }
     });
 }

--- a/src/websockets.rs
+++ b/src/websockets.rs
@@ -15,6 +15,8 @@ pub fn server_thread(
             let (stream, _) = server.accept()
                 .await.unwrap();
 
+            // TODO not sure if it's ok to ignore the error
+            // but it'll do for now
             if let Ok(ws) = accept_async(stream).await {
                 let _ = tx.send(ws);
             }


### PR DESCRIPTION
Opening in browser causes a `MissingConnectionUpgradeHeader`, which results in a panic