### PR TITLE
Reuse difficulty attributes from current_pp for fc_pp

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -258,6 +258,7 @@ fn process_reading_loop(
             values.current_pp = pp_current.pp();
 
             let fc_pp = AnyPP::new(beatmap)
+                .attributes(pp_current)
                 .mods(values.mods)
                 .mode(mode)
                 .n300(values.hit_300 as usize)


### PR DESCRIPTION
rosu-pp allows reusing difficulty attributes for same map-mod combinations, so this should be a tiny simple optimisation for that. Might come handy if someone added pp for x% later one because recalculating attributes doesn't scale well even with rosu-pp