### PR TITLE
Use gradual performance calculations for current pp

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -277,7 +277,7 @@ fn process_reading_loop(
                         .as_mut()
                         .unwrap()
                         .process_next_n_objects(score_state,delta)
-                        .expect(&*format!("delta: {}, delta sum: {}, total objects: {}", delta, values.delta_sum, beatmap.hit_objects.len()))
+                        .unwrap()
                         .pp();
                 }
             } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,6 +163,19 @@ fn process_reading_loop(
         values.folder = folder;
     }
 
+
+    // store the converted map so it's not converted 
+    // everytime it's used for pp calc
+    if new_map {
+        if let Some(map) = &values.current_beatmap {
+            if let Cow::Owned(converted) = map
+                .convert_mode(values.menu_gamemode()) 
+            {
+                values.current_beatmap = Some(converted);
+            }
+        }
+    }
+
     let ruleset_addr = p.read_i32(
         (p.read_i32(addresses.rulesets - 0xb)? + 0x4) as usize
     )?;
@@ -199,17 +212,6 @@ fn process_reading_loop(
 
         values.mode = p.read_i32(score_base + 0x64)?;
 
-        // store the converted map so it's not converted 
-        // everytime it's used for pp calc
-        if new_map {
-            if let Some(map) = &values.current_beatmap {
-                if let Cow::Owned(converted) = map
-                    .convert_mode(values.gameplay_gamemode()) 
-                {
-                    values.current_beatmap = Some(converted);
-                }
-            }
-        }
         values.hit_300 = p.read_i16(score_base + 0x8a)?;
         values.hit_100 = p.read_i16(score_base + 0x88)?;
         values.hit_50 = p.read_i16(score_base + 0x8c)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,8 +241,8 @@ fn process_reading_loop(
         values.hit_katu = p.read_i16(score_base + 0x90)?;
         values.hit_miss = p.read_i16(score_base + 0x92)?;
 
-        let passed_objects = values.passed_objects()?;
-        values.passed_objects = passed_objects;
+        // let passed_objects = values.passed_objects()?;
+        // values.passed_objects = passed_objects;
 
         values.accuracy = values.get_accuracy();
 
@@ -287,7 +287,7 @@ fn process_reading_loop(
                         n50: values.hit_50 as usize,
                         n_misses: values.hit_miss as usize,
             };
-            let passed_objects = values.passed_objects()?;
+            let passed_objects = values.passed_objects;
             let prev_passed_objects = values.prev_passed_objects;
             let delta = passed_objects - prev_passed_objects;
             let gradual_performance_current = &mut values.gradual_performance_current;
@@ -299,7 +299,8 @@ fn process_reading_loop(
                     };
                     GradualPerformanceAttributes::new(static_beatmap, values.mods)
                 });
-            if (delta > 0) && (values.passed_objects < beatmap.hit_objects.len()) {
+            println!("delta: {}, prev vs current: {}-{}, {}, {}", delta, passed_objects, prev_passed_objects, (delta > 0), passed_objects < beatmap.hit_objects.len());
+            if (delta > 0) && (passed_objects < beatmap.hit_objects.len()) {
                 values.current_pp = gradual.process_next_n_objects(score_state, delta)
                     .expect("process isn't called after the objects ended")
                     .pp();
@@ -329,6 +330,7 @@ fn process_reading_loop(
                 .timing_point_at(values.playtime as f64)
                 .beat_len;
 
+            values.passed_objects = values.passed_objects()?;
             values.prev_passed_objects = passed_objects;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -269,14 +269,12 @@ fn process_reading_loop(
             if gradual_performance_current.is_some() {
                 values.delta_sum += delta;
                 // Note: can't figure out how to properly satisfy the second part without storing delta_sum
-                // Note: other comparisons result in wrong pp values
-                // too sleepy to figure out
-                if (delta > 0) & (values.delta_sum <= beatmap.hit_objects.len() + 1) {
+                if (delta > 0) && (values.delta_sum < beatmap.hit_objects.len()) {
                     values.current_pp = gradual_performance_current
                         .as_mut()
                         .unwrap()
                         .process_next_n_objects(score_state,delta)
-                        .expect("calculations are fine")
+                        .expect("delta_sum doesn't exceed object count")
                         .pp();
                 }
             } else {

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -96,8 +96,6 @@ pub struct Values {
     pub prev_passed_objects: usize,
     #[serde(skip)]
     pub gradual_performance_current: Option<GradualPerformanceAttributes<'static>>,
-    #[serde(skip)]
-    pub delta_sum: usize,
 
     pub skin: String,
 
@@ -190,7 +188,6 @@ impl Values {
         self.bpm = 0.0;
         self.current_bpm = 0.0;
         self.prev_passed_objects = 0;
-        self.delta_sum = 0;
         self.gradual_performance_current = None;
         self.kiai_now = false;
     }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,6 +1,6 @@
 use std::{num::TryFromIntError, path::PathBuf};
 
-use rosu_pp::{Beatmap, GameMode};
+use rosu_pp::{Beatmap, GameMode, GradualPerformanceAttributes};
 use serde::Serialize;
 use serde_repr::Serialize_repr;
 
@@ -62,6 +62,10 @@ pub struct Values {
     pub prev_hit_miss: i16,
     #[serde(skip)]
     pub prev_playtime: i32,
+    #[serde(skip)]
+    pub prev_passed_objects: usize,
+    #[serde(skip)]
+    pub gradual_performance: Option<GradualPerformanceAttributes<'static>>,
 
     pub artist: String,
     pub folder: String,

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -145,6 +145,8 @@ pub struct Values {
     pub fc_pp: f64,
 
     pub passed_objects: usize,
+    #[serde(skip)]
+    pub delta_sum: usize,
 
     pub menu_mods: u32,
     pub mods: u32,
@@ -188,6 +190,7 @@ impl Values {
         self.bpm = 0.0;
         self.current_bpm = 0.0;
         self.prev_passed_objects = 0;
+        self.delta_sum = 0;
         self.gradual_performance_current = None;
         self.kiai_now = false;
     }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -65,7 +65,9 @@ pub struct Values {
     #[serde(skip)]
     pub prev_passed_objects: usize,
     #[serde(skip)]
-    pub gradual_performance: Option<GradualPerformanceAttributes<'static>>,
+    pub gradual_performance_current: Option<GradualPerformanceAttributes<'static>>,
+    #[serde(skip)]
+    pub delta_sum: usize,
 
     pub artist: String,
     pub folder: String,
@@ -148,6 +150,9 @@ impl Values {
 
         self.bpm = 0.0;
         self.current_bpm = 0.0;
+        self.prev_passed_objects = 0;
+        self.delta_sum = 0;
+        self.gradual_performance_current = None;
         self.kiai_now = false;
     }
 


### PR DESCRIPTION
Initial pass on this, closes #22

Adds usage of `GradualPerformanceAttributes` for `current_pp`. Requires some dirty hacks with passing the current beatmap, but fixing that would require refactoring the way values are generally stored OR the way `Values` is being referenced