### PR TITLE
Reduce calculations of Difficulty attributes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -296,18 +296,28 @@ fn process_reading_loop(
 
             values.current_pp = pp_current.pp();
 
-            let fc_pp = AnyPP::new(beatmap)
-                .mods(values.mods)
-                .mode(mode)
-                .n300(values.hit_300 as usize)
-                .n100(values.hit_100 as usize)
-                .n50(values.hit_50 as usize)
-                .n_geki(values.hit_geki as usize)
-                .n_katu(values.hit_katu as usize)
-                .n_misses(values.hit_miss as usize)
-                .calculate();
-
-            values.fc_pp = fc_pp.pp();
+            if values.current_beatmap_perf.is_some() {
+                if let Some(attributes) = values.current_beatmap_perf.clone() {
+                    let fc_pp = AnyPP::new(beatmap)
+                        .attributes(attributes.clone())
+                        .mods(values.mods)
+                        .n300(values.hit_300 as usize)
+                        .n100(values.hit_100 as usize)
+                        .n50(values.hit_50 as usize)
+                        .n_geki(values.hit_geki as usize)
+                        .n_katu(values.hit_katu as usize)
+                        .n_misses(values.hit_miss as usize)
+                        .calculate();
+                    values.fc_pp = fc_pp.pp();
+                }
+            } else {
+                let attr = AnyPP::new(beatmap)
+                    .mods(values.mods)
+                    .mode(values.gameplay_gamemode())
+                    .calculate();
+                values.ss_pp = attr.pp();
+                values.current_beatmap_perf = Some(attr);
+            }
 
             // TODO: get rid of extra allocation?
             let kiai_data: Option<EffectPoint> = beatmap

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,6 +1,6 @@
 use std::{num::TryFromIntError, path::PathBuf};
 
-use rosu_pp::{Beatmap, GameMode};
+use rosu_pp::{Beatmap, GameMode, PerformanceAttributes};
 use serde::Serialize;
 use serde_repr::Serialize_repr;
 
@@ -139,6 +139,9 @@ pub struct Values {
     // Calculated each iteration
     pub current_pp: f64,
     pub fc_pp: f64,
+    pub ss_pp: f64,
+    #[serde(skip)]
+    pub current_beatmap_perf: Option<PerformanceAttributes>,
 
     pub passed_objects: usize,
 
@@ -176,6 +179,8 @@ impl Values {
 
         self.current_pp = 0.0;
         self.fc_pp = 0.0;
+        self.ss_pp = 0.0;
+        self.current_beatmap_perf = None;
 
         self.passed_objects = 0;
 


### PR DESCRIPTION
Reduces the amount of times difficulty attributes are calculated for every play by storing them in Values.

Speed increase is worth the increased memory usage