### PR TITLE
Fix converted map sr

### DIFF
--- a/src/reading_loop.rs
+++ b/src/reading_loop.rs
@@ -99,7 +99,7 @@ pub fn process_reading_loop(
             let current_beatmap = match Beatmap::from_path(
                 &values.beatmap_full_path
             ) {
-                Ok(beatmap) => {
+                Ok(mut beatmap) => {
                     new_map = true;
 
                     values.background_file = 
@@ -113,6 +113,9 @@ pub fn process_reading_loop(
                         values.first_obj_time = hobj.start_time;
                     }
 
+                    if beatmap.mode != values.menu_gamemode() {
+                        beatmap = beatmap.convert_mode(values.menu_gamemode()).into_owned();
+                    }
 
                     Some(beatmap)
                 },

--- a/src/reading_loop.rs
+++ b/src/reading_loop.rs
@@ -113,9 +113,7 @@ pub fn process_reading_loop(
                         values.first_obj_time = hobj.start_time;
                     }
 
-                    if beatmap.mode != values.menu_gamemode() {
-                        beatmap = beatmap.convert_mode(values.menu_gamemode()).into_owned();
-                    }
+                    beatmap = beatmap.convert_mode(values.menu_gamemode()).into_owned();
 
                     Some(beatmap)
                 },


### PR DESCRIPTION
Fixes #52

I think that the `beatmap.convert_mode(mode)` function does clone the beatmap variable when it's used, but i don't know what we can do about that. i'm also not sure if that'd actually be an issue. i just threw this together in a few minutes.

I noticed that the star values are still slightly incorrect, but I think this is a rosu-pp issue, not a rosu-memory issue.