### PR TITLE
fix: converted sr not changing when changing menu_mode without changing beatmaps

### DIFF
--- a/src/reading_loop.rs
+++ b/src/reading_loop.rs
@@ -88,7 +88,6 @@ pub fn process_reading_loop(
         let beatmap_folder = p.read_string((beatmap_addr + 0x78) as usize)?;
         values.beatmap_id = p.read_i32(beatmap_addr as usize + 0xCC)?;
 
-        values.prev_menu_mode = values.menu_mode;
         values.menu_mode = p.read_i32(menu_mode_addr as usize)?;
 
         values.beatmap_full_path = values.osu_path.join("Songs/");
@@ -262,6 +261,7 @@ pub fn process_reading_loop(
         values.update_stars();
     }
 
+    values.prev_menu_mode = values.menu_mode;
     values.prev_menu_mods = menu_mods;
     values.prev_status = values.status;
 

--- a/src/reading_loop.rs
+++ b/src/reading_loop.rs
@@ -87,6 +87,8 @@ pub fn process_reading_loop(
         let beatmap_file = p.read_string((beatmap_addr + 0x90) as usize)?;
         let beatmap_folder = p.read_string((beatmap_addr + 0x78) as usize)?;
         values.beatmap_id = p.read_i32(beatmap_addr as usize + 0xCC)?;
+
+        values.prev_menu_mode = values.menu_mode;
         values.menu_mode = p.read_i32(menu_mode_addr as usize)?;
 
         values.beatmap_full_path = values.osu_path.join("Songs/");
@@ -94,7 +96,8 @@ pub fn process_reading_loop(
         values.beatmap_full_path.push(&beatmap_file);
 
         if (beatmap_folder != values.beatmap_folder 
-        || beatmap_file != values.beatmap_file)
+        || beatmap_file != values.beatmap_file
+        || values.prev_menu_mode != values.menu_mode)
         && values.beatmap_full_path.exists() {
             let current_beatmap = match Beatmap::from_path(
                 &values.beatmap_full_path

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -211,6 +211,8 @@ pub struct OutputValues {
     pub prev_status: GameStatus,
     #[serde(skip)]
     pub prev_menu_mods: u32,
+    #[serde(skip)]
+    pub prev_menu_mode: i32,
 
     pub skin: String,
 


### PR DESCRIPTION
Fixes #52

Adds `prev_menu_mode` field to the OutputValues struct, which is then used in the reading loop to detect if the menu_mode changed. If it does change, then it grabs the beatmap again and converts it again