### PR TITLE
fix: manually set mode when beatmap isn't cloned

### DIFF
--- a/src/reading_loop.rs
+++ b/src/reading_loop.rs
@@ -144,6 +144,11 @@ pub fn process_reading_loop(
             {
                 values.current_beatmap = Some(converted);
             }
+            else {
+                // manually set mode, since mode isn't changed for
+                // conversions to catch.
+                values.current_beatmap.as_mut().unwrap().mode = values.menu_gamemode();
+            }
         }
 
         values.update_stars();


### PR DESCRIPTION
fixes #55

found out that rosu-pp doesn't change the mode when converting to catch, so it just calculates the standard stars and pp. so you have to set it manually.

i'm unsure if this is the best way to do this, so i'm open to any better ideas